### PR TITLE
Fix: cannot find package "rand"

### DIFF
--- a/internal/app/resilience/denier.go
+++ b/internal/app/resilience/denier.go
@@ -6,11 +6,11 @@ package main
 import (
 	"encoding/hex"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/user"
 	"path"
-	"rand"
 	"runtime"
 	"runtime/debug"
 	"strings"


### PR DESCRIPTION
internal/app/resilience/denier.go:13:2: cannot find package "rand" in any of: